### PR TITLE
Rename the enforce_stack_size_limit option

### DIFF
--- a/src/fri/bitcoin_script.rs
+++ b/src/fri/bitcoin_script.rs
@@ -706,7 +706,7 @@ mod test {
                 verify_cltv: true,
                 verify_csv: true,
                 verify_minimal_if: true,
-                enforce_stack_size_limit: false,
+                enforce_stack_limit: false,
                 experimental: Experimental { op_cat: true },
             },
             TxTemplate {


### PR DESCRIPTION
The dependency https://github.com/Bitcoin-Wildlife-Sanctuary/rust-bitcoin-scriptexec/ has been rebased to stay close to the upstream BitVM repository. An option's name has been changed. This PR reconciles the corresponding change.