### PR TITLE
Fix the options for script execution

### DIFF
--- a/src/fibonacci/mod.rs
+++ b/src/fibonacci/mod.rs
@@ -1,0 +1,14 @@
+#[cfg(test)]
+mod test {
+    use stwo_prover::core::fields::m31::M31;
+    use stwo_prover::examples::fibonacci::Fibonacci;
+
+    #[test]
+    fn test_fib_prove() {
+        const FIB_LOG_SIZE: u32 = 5;
+        let fib = Fibonacci::new(FIB_LOG_SIZE, M31::reduce(443693538));
+
+        let proof = fib.prove().unwrap();
+        fib.verify(proof).unwrap();
+    }
+}

--- a/src/fri/bitcoin_script.rs
+++ b/src/fri/bitcoin_script.rs
@@ -707,7 +707,11 @@ mod test {
                 verify_csv: true,
                 verify_minimal_if: true,
                 enforce_stack_limit: false,
-                experimental: Experimental { op_cat: true },
+                experimental: Experimental {
+                    op_cat: true,
+                    op_mul: false,
+                    op_div: false,
+                },
             },
             TxTemplate {
                 tx: Transaction {

--- a/src/fri/bitcoin_script.rs
+++ b/src/fri/bitcoin_script.rs
@@ -376,8 +376,6 @@ mod test {
         println!("FRI.Twiddle-Tree = {} bytes", script.len());
 
         let exec_result = execute_script(script);
-        println!("{:8}", exec_result.final_stack);
-        println!("{:?}", exec_result.error);
         assert!(exec_result.success);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub mod circle;
 pub mod circle_secure;
 /// Module for constraints over the circle curve
 pub mod constraints;
+/// Module for Fibonacci end-to-end test.
+pub mod fibonacci;
 /// Module for FRI.
 pub mod fri;
 /// Module for the field and group arithmetics.


### PR DESCRIPTION
Due to merging the MUL+DIV fork into the main rust-bitcoin-scriptexec, the parameters have changed.

This is unexpected, and we may better refactor the script executor into a factory mode to allow different options and avoid apps to work on those internal structs directly.