### PR TITLE
Initial refactoring of the channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,14 @@ sha2 = "0.10.8"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 stwo-prover = { git = "https://github.com/starkware-libs/stwo", rev = "2c8b6e5" }
-stwo-fork = { git = "https://github.com/Bitcoin-Wildlife-Sanctuary/stwo-fork" }
 num-traits = "0.2.0"
 lazy_static = "1.4.0"
 ctor = "0.2.8"
+
+# reason: stwo-fork may use this repo's implementation of Channel, and therefore there is some circularity.
+# restricting the use of stwo-fork in this repository to test resolves it, but it is a temporary solution.
+[dev-dependencies]
+stwo-fork = { git = "https://github.com/Bitcoin-Wildlife-Sanctuary/stwo-fork" }
 
 # Add cargo-husky to run pre-commit hooks
 [dev-dependencies.cargo-husky]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,10 @@ bitcoin-scriptexec = { git = "https://github.com/Bitcoin-Wildlife-Sanctuary/rust
 sha2 = "0.10.8"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-stwo-prover = { git = "https://github.com/starkware-libs/stwo", rev = "2c8b6e5" }
+stwo-prover = { git = "https://github.com/Bitcoin-Wildlife-Sanctuary/stwo" }
 num-traits = "0.2.0"
 lazy_static = "1.4.0"
 ctor = "0.2.8"
-
-# reason: stwo-fork may use this repo's implementation of Channel, and therefore there is some circularity.
-# restricting the use of stwo-fork in this repository to test resolves it, but it is a temporary solution.
-[dev-dependencies]
-stwo-fork = { git = "https://github.com/Bitcoin-Wildlife-Sanctuary/stwo-fork" }
 
 # Add cargo-husky to run pre-commit hooks
 [dev-dependencies.cargo-husky]

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -1,127 +1,44 @@
-use crate::utils::{hash_qm31, trim_m31};
+use crate::utils::trim_m31;
 use bitcoin::script::PushBytesBuf;
 use sha2::{Digest, Sha256};
 use std::ops::Neg;
 use stwo_prover::core::channel::Channel;
 use stwo_prover::core::fields::cm31::CM31;
 use stwo_prover::core::fields::m31::M31;
-use stwo_prover::core::fields::qm31::{SecureField, QM31};
+use stwo_prover::core::fields::qm31::QM31;
 
 mod bitcoin_script;
 use crate::treepp::pushable::{Builder, Pushable};
 pub use bitcoin_script::*;
 
-/// A channel.
-pub struct Sha256Channel {
-    /// Current state of the channel.
-    pub state: [u8; 32],
-}
+pub use stwo_prover::core::channel::BWSSha256Channel as Sha256Channel;
+use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hash;
 
-impl Channel for Sha256Channel {
-    type Digest = [u8; 32];
-    const BYTES_PER_HASH: usize = 32;
-
-    fn new(digest: Self::Digest) -> Self {
-        Self { state: digest }
-    }
-
-    fn get_digest(&self) -> Self::Digest {
-        self.state
-    }
-
-    fn mix_digest(&mut self, digest: Self::Digest) {
-        let mut hasher = Sha256::new();
-        Digest::update(&mut hasher, digest);
-        Digest::update(&mut hasher, self.state);
-        self.state.copy_from_slice(hasher.finalize().as_slice());
-    }
-
-    fn mix_felts(&mut self, felts: &[SecureField]) {
-        for felt in felts.iter() {
-            let mut hasher = Sha256::new();
-            Digest::update(&mut hasher, hash_qm31(felt));
-            Digest::update(&mut hasher, self.state);
-            self.state.copy_from_slice(hasher.finalize().as_slice());
-        }
-    }
-
-    fn mix_nonce(&mut self, nonce: u64) {
-        // mix_nonce is called during PoW. However, later we plan to replace it by a Bitcoin block
-        // inclusion proof, then this function would never be called.
-
-        let mut hash = [0u8; 32];
-        hash[..8].copy_from_slice(&nonce.to_le_bytes());
-
-        self.mix_digest(hash);
-    }
-
-    fn draw_felt(&mut self) -> SecureField {
-        let mut extract = [0u8; 32];
-
-        let mut hasher = Sha256::new();
-        Digest::update(&mut hasher, self.state);
-        Digest::update(&mut hasher, [0u8]);
-        extract.copy_from_slice(hasher.finalize().as_slice());
-
-        let mut hasher = Sha256::new();
-        Digest::update(&mut hasher, self.state);
-        self.state.copy_from_slice(hasher.finalize().as_slice());
-
-        let (res_1, _) = Self::extract_common(&extract);
-        let (res_2, _) = Self::extract_common(&extract[4..]);
-        let (res_3, _) = Self::extract_common(&extract[8..]);
-        let (res_4, _) = Self::extract_common(&extract[12..]);
-
-        QM31(CM31(res_1, res_2), CM31(res_3, res_4))
-    }
-
-    fn draw_felts(&mut self, n_felts: usize) -> Vec<SecureField> {
-        let mut res = vec![];
-        for _ in 0..n_felts {
-            res.push(self.draw_felt());
-        }
-        res
-    }
-
-    fn draw_random_bytes(&mut self) -> Vec<u8> {
-        let mut extract = [0u8; 32];
-
-        let mut hasher = Sha256::new();
-        Digest::update(&mut hasher, self.state);
-        Digest::update(&mut hasher, [0u8]);
-        extract.copy_from_slice(hasher.finalize().as_slice());
-
-        let mut hasher = Sha256::new();
-        Digest::update(&mut hasher, self.state);
-        self.state.copy_from_slice(hasher.finalize().as_slice());
-
-        extract.to_vec()
-    }
-}
-
-impl Sha256Channel {
-    /// Initialize a new channel.
-    pub fn new(hash: [u8; 32]) -> Self {
-        Self { state: hash }
-    }
-
+/// A wrapper trait to implement hint-related method for channels.
+pub trait ChannelWithHint: Channel {
     /// Draw one qm31 and compute the hints.
-    pub fn draw_felt_and_hints(&mut self) -> (QM31, ExtractionQM31) {
+    fn draw_felt_and_hints(&mut self) -> (QM31, ExtractionQM31);
+    /// Draw five queries and compute the hints.
+    fn draw_5queries(&mut self, logn: usize) -> ([usize; 5], Extraction5M31);
+}
+
+impl ChannelWithHint for Sha256Channel {
+    fn draw_felt_and_hints(&mut self) -> (QM31, ExtractionQM31) {
         let mut extract = [0u8; 32];
 
         let mut hasher = Sha256::new();
-        Digest::update(&mut hasher, self.state);
+        Digest::update(&mut hasher, self.digest);
         Digest::update(&mut hasher, [0u8]);
         extract.copy_from_slice(hasher.finalize().as_slice());
 
         let mut hasher = Sha256::new();
-        Digest::update(&mut hasher, self.state);
-        self.state.copy_from_slice(hasher.finalize().as_slice());
+        Digest::update(&mut hasher, self.digest);
+        self.digest = BWSSha256Hash::from(hasher.finalize().to_vec());
 
-        let (res_1, hint_1) = Self::extract_common(&extract);
-        let (res_2, hint_2) = Self::extract_common(&extract[4..]);
-        let (res_3, hint_3) = Self::extract_common(&extract[8..]);
-        let (res_4, hint_4) = Self::extract_common(&extract[12..]);
+        let (res_1, hint_1) = extract_common(&extract);
+        let (res_2, hint_2) = extract_common(&extract[4..]);
+        let (res_3, hint_3) = extract_common(&extract[8..]);
+        let (res_4, hint_4) = extract_common(&extract[12..]);
 
         let mut hint_bytes = [0u8; 16];
         hint_bytes.copy_from_slice(&extract[16..]);
@@ -132,24 +49,23 @@ impl Sha256Channel {
         )
     }
 
-    /// Draw five queries and compute the hints.
-    pub fn draw_5queries(&mut self, logn: usize) -> ([usize; 5], Extraction5M31) {
+    fn draw_5queries(&mut self, logn: usize) -> ([usize; 5], Extraction5M31) {
         let mut extract = [0u8; 32];
 
         let mut hasher = Sha256::new();
-        Digest::update(&mut hasher, self.state);
+        Digest::update(&mut hasher, self.digest);
         Digest::update(&mut hasher, [0u8]);
         extract.copy_from_slice(hasher.finalize().as_slice());
 
         let mut hasher = Sha256::new();
-        Digest::update(&mut hasher, self.state);
-        self.state.copy_from_slice(hasher.finalize().as_slice());
+        Digest::update(&mut hasher, self.digest);
+        self.digest = BWSSha256Hash::from(hasher.finalize().to_vec());
 
-        let (res_1, hint_1) = Self::extract_common(&extract);
-        let (res_2, hint_2) = Self::extract_common(&extract[4..]);
-        let (res_3, hint_3) = Self::extract_common(&extract[8..]);
-        let (res_4, hint_4) = Self::extract_common(&extract[12..]);
-        let (res_5, hint_5) = Self::extract_common(&extract[16..]);
+        let (res_1, hint_1) = extract_common(&extract);
+        let (res_2, hint_2) = extract_common(&extract[4..]);
+        let (res_3, hint_3) = extract_common(&extract[8..]);
+        let (res_4, hint_4) = extract_common(&extract[12..]);
+        let (res_5, hint_5) = extract_common(&extract[16..]);
 
         let mut hint_bytes = [0u8; 12];
         hint_bytes.copy_from_slice(&extract[20..]);
@@ -172,28 +88,28 @@ impl Sha256Channel {
             hint,
         )
     }
+}
 
-    fn extract_common(hash: &[u8]) -> (M31, ExtractorHint) {
-        let mut bytes = [0u8; 4];
-        bytes.copy_from_slice(&hash[0..4]);
+fn extract_common(hash: &[u8]) -> (M31, ExtractorHint) {
+    let mut bytes = [0u8; 4];
+    bytes.copy_from_slice(&hash[0..4]);
 
-        let mut res = u32::from_le_bytes(bytes);
-        res &= 0x7fffffff;
+    let mut res = u32::from_le_bytes(bytes);
+    res &= 0x7fffffff;
 
-        let hint = if bytes[3] & 0x80 != 0 {
-            if res == 0 {
-                ExtractorHint::NegativeZero
-            } else {
-                ExtractorHint::Other((res as i64).neg())
-            }
+    let hint = if bytes[3] & 0x80 != 0 {
+        if res == 0 {
+            ExtractorHint::NegativeZero
         } else {
-            ExtractorHint::Other(res as i64)
-        };
+            ExtractorHint::Other((res as i64).neg())
+        }
+    } else {
+        ExtractorHint::Other(res as i64)
+    };
 
-        res = res.saturating_sub(1);
+    res = res.saturating_sub(1);
 
-        (M31::from(res), hint)
-    }
+    (M31::from(res), hint)
 }
 
 /// Basic hint structure for extracting a single qm31 element.

--- a/src/fibonacci/mod.rs
+++ b/src/fibonacci/mod.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod test {
-    use stwo_fork::core::prover::{prove, verify};
-    use stwo_prover::core::channel::{Blake2sChannel, Channel};
+    use stwo_prover::core::channel::{BWSSha256Channel, Channel};
     use stwo_prover::core::fields::m31::{BaseField, M31};
     use stwo_prover::core::fields::IntoSlice;
-    use stwo_prover::core::vcs::blake2_hash::Blake2sHasher;
+    use stwo_prover::core::prover::{prove, verify};
+    use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hasher;
     use stwo_prover::core::vcs::hasher::Hasher;
     use stwo_prover::examples::fibonacci::Fibonacci;
 
@@ -14,16 +14,18 @@ mod test {
         let fib = Fibonacci::new(FIB_LOG_SIZE, M31::reduce(443693538));
 
         let trace = fib.get_trace();
-        let channel = &mut Blake2sChannel::new(Blake2sHasher::hash(BaseField::into_slice(&[fib
-            .air
-            .component
-            .claim])));
+        let channel =
+            &mut BWSSha256Channel::new(BWSSha256Hasher::hash(BaseField::into_slice(&[fib
+                .air
+                .component
+                .claim])));
         let proof = prove(&fib.air, channel, vec![trace]).unwrap();
 
-        let channel = &mut Blake2sChannel::new(Blake2sHasher::hash(BaseField::into_slice(&[fib
-            .air
-            .component
-            .claim])));
+        let channel =
+            &mut BWSSha256Channel::new(BWSSha256Hasher::hash(BaseField::into_slice(&[fib
+                .air
+                .component
+                .claim])));
         verify(proof, &fib.air, channel).unwrap()
     }
 }

--- a/src/fri/bitcoin_script.rs
+++ b/src/fri/bitcoin_script.rs
@@ -28,10 +28,7 @@ impl FRIGadget {
             let res = channel.draw_felt_and_hints();
             factors_hints.push(res.1);
         }
-        proof
-            .last_layer
-            .iter()
-            .for_each(|v| channel.mix_felts(&[*v]));
+        channel.mix_felts(&proof.last_layer);
 
         let res = channel.draw_5queries(logn);
         let queries_hint = res.1;
@@ -269,10 +266,10 @@ mod test {
     use crate::channel::Sha256Channel;
     use crate::fri;
     use crate::fri::{FFTGadget, FRIGadget, N_QUERIES};
+    use crate::tests_utils::report::report_bitcoin_script_size;
     use crate::treepp::*;
     use crate::twiddle_merkle_tree::{TwiddleMerkleTree, TWIDDLE_MERKLE_TREE_ROOT_18};
     use crate::utils::permute_eval;
-    use crate::tests_utils::report::report_bitcoin_script_size;
     use bitcoin::hashes::Hash;
     use bitcoin::{TapLeafHash, Transaction};
     use bitcoin_scriptexec::{Exec, ExecCtx, Experimental, Options, TxTemplate};

--- a/src/fri/bitcoin_script.rs
+++ b/src/fri/bitcoin_script.rs
@@ -1,4 +1,6 @@
-use crate::channel::{ChannelWithHint, ExtractionQM31, ExtractorGadget, Sha256Channel, Sha256ChannelGadget};
+use crate::channel::{
+    ChannelWithHint, ExtractionQM31, ExtractorGadget, Sha256Channel, Sha256ChannelGadget,
+};
 use crate::fri::{FriProof, N_QUERIES};
 use crate::merkle_tree::MerkleTreeGadget;
 use crate::treepp::*;
@@ -42,11 +44,7 @@ impl FRIGadget {
     }
 
     /// Check the Fiat-Shamir computation.
-    pub fn check_fiat_shamir(
-        channel_init_state: &[u8],
-        logn: usize,
-        n_layers: usize,
-    ) -> Script {
+    pub fn check_fiat_shamir(channel_init_state: &[u8], logn: usize, n_layers: usize) -> Script {
         assert_eq!(channel_init_state.len(), 32);
         let n_last_layer = 1 << (logn - n_layers);
         script! {

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -1,4 +1,4 @@
-use crate::channel::Sha256Channel;
+use crate::channel::{ChannelWithHint, Sha256Channel};
 use crate::merkle_tree::{MerkleTree, MerkleTreeProof};
 use crate::twiddle_merkle_tree::{TwiddleMerkleTree, TwiddleMerkleTreeProof};
 use crate::utils::get_twiddles;
@@ -6,6 +6,7 @@ use stwo_prover::core::channel::Channel;
 use stwo_prover::core::fft::ibutterfly;
 use stwo_prover::core::fields::qm31::QM31;
 use stwo_prover::core::fields::FieldExpOps;
+use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hash;
 
 mod bitcoin_script;
 pub use bitcoin_script::*;
@@ -13,7 +14,7 @@ pub use bitcoin_script::*;
 /// A FRI proof.
 #[derive(Clone, Debug)]
 pub struct FriProof {
-    commitments: Vec<[u8; 32]>,
+    commitments: Vec<BWSSha256Hash>,
     last_layer: Vec<QM31>,
     leaves: Vec<QM31>,
     merkle_proofs: Vec<Vec<MerkleTreeProof>>,
@@ -130,7 +131,7 @@ pub fn fri_verify(
         ));
         for (i, (eval_proof, &alpha)) in merkle_proof.iter().zip(factors.iter()).enumerate() {
             assert!(MerkleTree::verify(
-                proof.commitments[i],
+                &proof.commitments[i],
                 logn - i,
                 &merkle_proof[i],
                 query ^ 1

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -1,8 +1,8 @@
-use crate::channel::Channel;
-use crate::channel::Commitment;
+use crate::channel::Sha256Channel;
 use crate::merkle_tree::{MerkleTree, MerkleTreeProof};
 use crate::twiddle_merkle_tree::{TwiddleMerkleTree, TwiddleMerkleTreeProof};
 use crate::utils::get_twiddles;
+use stwo_prover::core::channel::Channel;
 use stwo_prover::core::fft::ibutterfly;
 use stwo_prover::core::fields::qm31::QM31;
 use stwo_prover::core::fields::FieldExpOps;
@@ -13,7 +13,7 @@ pub use bitcoin_script::*;
 /// A FRI proof.
 #[derive(Clone, Debug)]
 pub struct FriProof {
-    commitments: Vec<Commitment>,
+    commitments: Vec<[u8; 32]>,
     last_layer: Vec<QM31>,
     leaves: Vec<QM31>,
     merkle_proofs: Vec<Vec<MerkleTreeProof>>,
@@ -23,7 +23,7 @@ pub struct FriProof {
 const N_QUERIES: usize = 5; // cannot change. hardcoded in the Channel implementation
 
 /// Generate a FRI proof.
-pub fn fri_prove(channel: &mut Channel, evaluation: Vec<QM31>) -> FriProof {
+pub fn fri_prove(channel: &mut Sha256Channel, evaluation: Vec<QM31>) -> FriProof {
     let logn = evaluation.len().ilog2() as usize;
     let n_layers = logn - 1;
     let twiddles = get_twiddles(logn);
@@ -39,13 +39,12 @@ pub fn fri_prove(channel: &mut Channel, evaluation: Vec<QM31>) -> FriProof {
 
         let tree = MerkleTree::new(layer.clone());
 
-        let commitment = Commitment(tree.root_hash);
-        channel.absorb_commitment(&commitment);
-        commitments.push(commitment);
+        channel.mix_digest(tree.root_hash);
+        commitments.push(tree.root_hash);
 
         trees.push(tree);
 
-        let (alpha, _) = channel.draw_qm31();
+        let (alpha, _) = channel.draw_felt_and_hints();
 
         layer = layer
             .chunks_exact(2)
@@ -60,7 +59,7 @@ pub fn fri_prove(channel: &mut Channel, evaluation: Vec<QM31>) -> FriProof {
 
     // Last layer.
     let last_layer = layer;
-    last_layer.iter().for_each(|v| channel.absorb_qm31(v));
+    channel.mix_felts(&last_layer);
 
     // Queries.
     let queries = channel.draw_5queries(logn).0.to_vec();
@@ -93,7 +92,7 @@ pub fn fri_prove(channel: &mut Channel, evaluation: Vec<QM31>) -> FriProof {
 
 /// Verify the FRI proof.
 pub fn fri_verify(
-    channel: &mut Channel,
+    channel: &mut Sha256Channel,
     logn: usize,
     proof: FriProof,
     twiddle_merkle_tree_root: [u8; 32],
@@ -103,11 +102,11 @@ pub fn fri_verify(
     // Draw factors.
     let mut factors = Vec::with_capacity(n_layers);
     for c in proof.commitments.iter() {
-        channel.absorb_commitment(c);
-        factors.push(channel.draw_qm31().0);
+        channel.mix_digest(*c);
+        factors.push(channel.draw_felt_and_hints().0);
     }
     // Last layer.
-    proof.last_layer.iter().for_each(|v| channel.absorb_qm31(v));
+    channel.mix_felts(&proof.last_layer);
     // Check it's of half degree.
     assert_eq!(proof.last_layer[0], proof.last_layer[1]);
     // Queries.
@@ -131,7 +130,7 @@ pub fn fri_verify(
         ));
         for (i, (eval_proof, &alpha)) in merkle_proof.iter().zip(factors.iter()).enumerate() {
             assert!(MerkleTree::verify(
-                proof.commitments[i].0,
+                proof.commitments[i],
                 logn - i,
                 &merkle_proof[i],
                 query ^ 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ mod test {
         let mut channel_init_state = [0u8; 32];
         channel_init_state.iter_mut().for_each(|v| *v = prng.gen());
 
-        let channel_init_state= BWSSha256Hash::from(channel_init_state.to_vec());
+        let channel_init_state = BWSSha256Hash::from(channel_init_state.to_vec());
 
         // Note: Add another .square() to make the proof fail.
         let evaluation = (0..(1 << logn))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use crate::treepp::pushable::{Builder, Pushable};
 use stwo_prover::core::fields::cm31::CM31;
 use stwo_prover::core::fields::m31::M31;
 use stwo_prover::core::fields::qm31::QM31;
+use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hash;
 
 /// Module for absorbing and squeezing of the channel.
 pub mod channel;
@@ -60,6 +61,12 @@ impl Pushable for QM31 {
     }
 }
 
+impl Pushable for BWSSha256Hash {
+    fn bitcoin_script_push(self, builder: Builder) -> Builder {
+        self.as_ref().to_vec().bitcoin_script_push(builder)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::channel::Sha256Channel;
@@ -69,10 +76,12 @@ mod test {
     use num_traits::One;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
+    use stwo_prover::core::channel::Channel;
     use stwo_prover::core::circle::CirclePointIndex;
     use stwo_prover::core::fields::m31::M31;
     use stwo_prover::core::fields::qm31::QM31;
     use stwo_prover::core::fields::FieldExpOps;
+    use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hash;
 
     #[test]
     fn test_cfri_main() {
@@ -84,6 +93,8 @@ mod test {
 
         let mut channel_init_state = [0u8; 32];
         channel_init_state.iter_mut().for_each(|v| *v = prng.gen());
+
+        let channel_init_state= BWSSha256Hash::from(channel_init_state.to_vec());
 
         // Note: Add another .square() to make the proof fail.
         let evaluation = (0..(1 << logn))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ impl Pushable for QM31 {
 
 #[cfg(test)]
 mod test {
-    use crate::channel::Channel;
+    use crate::channel::Sha256Channel;
     use crate::fri;
     use crate::twiddle_merkle_tree::TWIDDLE_MERKLE_TREE_ROOT_4;
     use crate::utils::permute_eval;
@@ -92,9 +92,9 @@ mod test {
         let evaluation = permute_eval(evaluation);
 
         // FRI.
-        let proof = fri::fri_prove(&mut Channel::new(channel_init_state), evaluation);
+        let proof = fri::fri_prove(&mut Sha256Channel::new(channel_init_state), evaluation);
         fri::fri_verify(
-            &mut Channel::new(channel_init_state),
+            &mut Sha256Channel::new(channel_init_state),
             logn,
             proof,
             TWIDDLE_MERKLE_TREE_ROOT_4,

--- a/src/merkle_tree/bitcoin_script.rs
+++ b/src/merkle_tree/bitcoin_script.rs
@@ -127,7 +127,7 @@ mod test {
 
             let script = script! {
                 { MerkleTreeGadget::push_merkle_tree_proof(&proof) }
-                { merkle_tree.root_hash.to_vec() }
+                { merkle_tree.root_hash }
                 { pos }
                 { verify_script.clone() }
                 { last_layer[pos as usize] }
@@ -164,7 +164,7 @@ mod test {
 
             let script = script! {
                 { MerkleTreeGadget::push_merkle_tree_proof(&proof) }
-                { merkle_tree.root_hash.to_vec() }
+                { merkle_tree.root_hash }
                 { pos }
                 { verify_script.clone() }
                 { last_layer[(pos ^ 1) as usize] }

--- a/src/merkle_tree/bitcoin_script.rs
+++ b/src/merkle_tree/bitcoin_script.rs
@@ -1,7 +1,6 @@
-use crate::channel::CommitmentGadget;
 use crate::merkle_tree::MerkleTreeProof;
 use crate::treepp::*;
-use crate::utils::limb_to_be_bits_toaltstack;
+use crate::utils::{hash_felt_gadget, limb_to_be_bits_toaltstack};
 
 /// Gadget for verifying a regular binary Merkle tree.
 pub struct MerkleTreeGadget;
@@ -35,7 +34,7 @@ impl MerkleTreeGadget {
             OP_2ROT
             OP_2SWAP
 
-            { CommitmentGadget::commit_qm31() }
+            hash_felt_gadget
 
             if is_sibling {
                 OP_DEPTH OP_1SUB OP_ROLL

--- a/src/merkle_tree/mod.rs
+++ b/src/merkle_tree/mod.rs
@@ -1,5 +1,6 @@
 use sha2::{Digest, Sha256};
 use stwo_prover::core::fields::qm31::QM31;
+use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hash;
 
 mod bitcoin_script;
 use crate::utils::hash_qm31;
@@ -12,7 +13,7 @@ pub struct MerkleTree {
     /// Intermediate layers.
     pub intermediate_layers: Vec<Vec<[u8; 32]>>,
     /// Root hash.
-    pub root_hash: [u8; 32],
+    pub root_hash: BWSSha256Hash,
 }
 
 impl MerkleTree {
@@ -56,7 +57,7 @@ impl MerkleTree {
         Self {
             leaf_layer,
             intermediate_layers,
-            root_hash: cur[0],
+            root_hash: BWSSha256Hash::from(cur[0].to_vec()),
         }
     }
 
@@ -85,7 +86,7 @@ impl MerkleTree {
 
     /// Verify a Merkle tree proof.
     pub fn verify(
-        root_hash: [u8; 32],
+        root_hash: &BWSSha256Hash,
         logn: usize,
         proof: &MerkleTreeProof,
         mut query: usize,
@@ -109,7 +110,7 @@ impl MerkleTree {
             query >>= 1;
         }
 
-        leaf_hash == root_hash
+        leaf_hash == root_hash.as_ref()
     }
 }
 
@@ -149,7 +150,7 @@ mod test {
             let query = (prng.gen::<u32>() % (1 << 12)) as usize;
 
             let proof = merkle_tree.query(query);
-            assert!(MerkleTree::verify(merkle_tree.root_hash, 12, &proof, query));
+            assert!(MerkleTree::verify(&merkle_tree.root_hash, 12, &proof, query));
         }
     }
 }

--- a/src/merkle_tree/mod.rs
+++ b/src/merkle_tree/mod.rs
@@ -150,7 +150,12 @@ mod test {
             let query = (prng.gen::<u32>() % (1 << 12)) as usize;
 
             let proof = merkle_tree.query(query);
-            assert!(MerkleTree::verify(&merkle_tree.root_hash, 12, &proof, query));
+            assert!(MerkleTree::verify(
+                &merkle_tree.root_hash,
+                12,
+                &proof,
+                query
+            ));
         }
     }
 }

--- a/src/oods/bitcoin_script.rs
+++ b/src/oods/bitcoin_script.rs
@@ -1,4 +1,4 @@
-use crate::channel::ChannelGadget;
+use crate::channel::Sha256ChannelGadget;
 use crate::treepp::*;
 use rust_bitcoin_m31::{
     m31_add_n31, m31_sub, push_m31_one, push_n31_one, qm31_double, qm31_dup, qm31_equalverify,
@@ -28,7 +28,7 @@ impl OODSGadget {
     /// where (x,y) - random point on C(QM31) satisfying x^2+y^2=1 (8 elements)
     pub fn get_random_point() -> Script {
         script! {
-            { ChannelGadget::squeeze_qm31_using_hint() }
+            { Sha256ChannelGadget::squeeze_qm31_using_hint() }
             // stack: x, y, channel', t
 
             // compute t^2 from t
@@ -84,7 +84,7 @@ mod test {
     use crate::oods::{OODSGadget, OODS};
     use crate::treepp::*;
     use crate::{
-        channel::{Channel, ExtractorGadget},
+        channel::{Sha256Channel, ExtractorGadget},
         tests_utils::report::report_bitcoin_script_size,
     };
     use rand::{Rng, SeedableRng};
@@ -102,7 +102,7 @@ mod test {
         let mut a = [0u8; 32];
         a.iter_mut().for_each(|v| *v = prng.gen());
 
-        let mut channel = Channel::new(a);
+        let mut channel = Sha256Channel::new(a);
 
         let (p, hint_t) = OODS::get_random_point(&mut channel);
 

--- a/src/oods/bitcoin_script.rs
+++ b/src/oods/bitcoin_script.rs
@@ -84,7 +84,7 @@ mod test {
     use crate::oods::{OODSGadget, OODS};
     use crate::treepp::*;
     use crate::{
-        channel::{Sha256Channel, ExtractorGadget},
+        channel::{ExtractorGadget, Sha256Channel},
         tests_utils::report::report_bitcoin_script_size,
     };
     use rand::{Rng, SeedableRng};

--- a/src/oods/mod.rs
+++ b/src/oods/mod.rs
@@ -1,4 +1,4 @@
-use crate::channel::ExtractionQM31;
+use crate::channel::{ChannelWithHint, ExtractionQM31};
 use crate::channel::Sha256Channel;
 use num_traits::One;
 use std::ops::{Add, Mul, Neg};

--- a/src/oods/mod.rs
+++ b/src/oods/mod.rs
@@ -1,5 +1,5 @@
-use crate::channel::{ChannelWithHint, ExtractionQM31};
 use crate::channel::Sha256Channel;
+use crate::channel::{ChannelWithHint, ExtractionQM31};
 use num_traits::One;
 use std::ops::{Add, Mul, Neg};
 use stwo_prover::core::circle::CirclePoint;

--- a/src/oods/mod.rs
+++ b/src/oods/mod.rs
@@ -1,5 +1,5 @@
-use crate::channel::Channel;
 use crate::channel::ExtractionQM31;
+use crate::channel::Sha256Channel;
 use num_traits::One;
 use std::ops::{Add, Mul, Neg};
 use stwo_prover::core::circle::CirclePoint;
@@ -14,8 +14,8 @@ pub struct OODS;
 
 impl OODS {
     /// Obtain a random point from the channel and its hint.
-    pub fn get_random_point(channel: &mut Channel) -> (CirclePoint<QM31>, ExtractionQM31) {
-        let (t, hint) = channel.draw_qm31();
+    pub fn get_random_point(channel: &mut Sha256Channel) -> (CirclePoint<QM31>, ExtractionQM31) {
+        let (t, hint) = channel.draw_felt_and_hints();
 
         let one_plus_tsquared_inv = t.square().add(QM31::one()).inverse();
 

--- a/src/utils/bitcoin_script.rs
+++ b/src/utils/bitcoin_script.rs
@@ -45,6 +45,13 @@ pub fn copy_to_altstack_top_item_last_in(n: usize) -> Script {
     }
 }
 
+/// Gadget for hashing a qm31 element in the script.
+pub fn hash_felt_gadget() -> Script {
+    script! {
+        OP_SHA256 OP_CAT OP_SHA256 OP_CAT OP_SHA256 OP_CAT OP_SHA256
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::treepp::*;


### PR DESCRIPTION
This PR mainly wants to use a `Sha256Channel` that implements the `Channel` trait and can replace the Blake2 channel used in stwo for proof generation. This has been done in the stwo fork.

A few changes are made:
- update the README on the terminology about absorbing
- remove `Commitment` and `CommitmentGadget` and move the corresponding functions to `utils`
- use stwo fork's implementation for Sha256 channel
- update the fibonacci ref implementation to use Sha256 channel