### PR TITLE
Composition polynomial implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ stwo-fork = { git = "https://github.com/Bitcoin-Wildlife-Sanctuary/stwo-fork" }
 num-traits = "0.2.0"
 lazy_static = "1.4.0"
 ctor = "0.2.8"
+itertools = "0.12.0"
 
 # Add cargo-husky to run pre-commit hooks
 [dev-dependencies.cargo-husky]

--- a/src/fibonacci/bitcoin_script.rs
+++ b/src/fibonacci/bitcoin_script.rs
@@ -375,7 +375,6 @@ mod test {
         }
     }
 
-    //TODO: efficiency report
     #[test]
     fn test_step_constraint_eval_quotient_by_mask() {
         let log_size = 5;

--- a/src/fibonacci/bitcoin_script.rs
+++ b/src/fibonacci/bitcoin_script.rs
@@ -1,0 +1,179 @@
+use core::slice;
+
+use crate::{constraints::ConstraintsGadget, fibonacci::FibonacciComposition, treepp::*};
+use num_traits::One;
+use rust_bitcoin_m31::qm31_add;
+use rust_bitcoin_m31::qm31_dup;
+use rust_bitcoin_m31::qm31_equalverify;
+use rust_bitcoin_m31::qm31_from_bottom;
+use rust_bitcoin_m31::{
+    qm31_fromaltstack, qm31_mul, qm31_mul_m31, qm31_roll, qm31_sub, qm31_toaltstack,
+};
+use stwo_prover::core::{
+    circle::{CirclePoint, Coset},
+    fields::{m31::M31, qm31::QM31, FieldExpOps},
+};
+
+/// Gadget for Fibonacci composition polynomial-related operations.
+pub struct FibonacciCompositionGadget;
+
+impl FibonacciCompositionGadget {
+    /*fn step_constraint_eval_quotient_by_mask() -> Script {
+        script! {
+
+        }
+    }*/
+
+    ///hint
+    #[allow(dead_code)]
+    fn boundary_constraint_eval_quotient_by_mask_hint(
+        log_size: u32,
+        claim: M31,
+        z: CirclePoint<QM31>,
+        fz: QM31,
+    ) -> Script {
+        let res = FibonacciComposition::boundary_constraint_eval_quotient_by_mask(
+            log_size,
+            claim,
+            z,
+            slice::from_ref(&fz).try_into().unwrap(),
+        );
+
+        script! {
+            { res }
+        }
+    }
+
+    //give result as hint, compute num,denom yourself and verify
+    ///hint:
+    /// num/denom
+    ///input:
+    /// f(z)
+    /// z.x
+    /// z.y
+    ///output:
+    /// num/denom
+    #[allow(dead_code)]
+    fn boundary_constraint_eval_quotient_by_mask(log_size: u32, claim: M31) -> Script {
+        let constraint_zero_domain = Coset::subgroup(log_size);
+        let p = constraint_zero_domain.at(constraint_zero_domain.size() - 1);
+        script! {
+            qm31_dup
+            qm31_toaltstack
+            { qm31_roll(1) }
+            qm31_toaltstack //stack: f(z), z.y; altstack: z.y, z.x
+
+            { (claim - M31::one()) * p.y.inverse() }
+            qm31_mul_m31
+
+            { QM31::one() }
+            qm31_add //linear = QM31::one() + z.y * (self.claim - M31::one()) * p.y.inverse();
+
+            qm31_sub //num = f(z) - linear
+            //OP_RETURN
+
+            qm31_fromaltstack //bring back z.x from altstack
+            qm31_fromaltstack //bring back z.y from altstack
+            { ConstraintsGadget::pair_vanishing(p.into_ef(), CirclePoint::zero())} //denom
+
+            qm31_from_bottom //pull num/denom from hint
+
+            qm31_dup
+            qm31_toaltstack //store num/denom in altstack
+
+            qm31_mul //(num/denom)*denom
+
+            qm31_equalverify //check that num==(num/denom)*denom
+
+            qm31_fromaltstack //return num/denom
+        }
+    }
+
+    //step_constraint_eval_quotient_by_mask(f(z'),f(G z'),f(G^2 z'),z)*alpha + boundary_constraint_eval_quotient_by_mask(f(z'),z)
+    //eval_composition_polynomial_at_point()->evaluate_constraint_quotients_at_point()->
+    //no accumulator
+    //alpha should be taken from channel
+
+    /*
+    ///input:
+    /// alpha
+    /// f(G^2 z)
+    /// f(Gz)
+    /// f(z) (QM31)
+    /// z.x
+    /// z.y
+    fn eval_composition_polynomial_at_point(log_size: u32, claim: M31) -> Script {
+        script! {
+
+        }
+    }*/
+}
+
+#[cfg(test)]
+mod test {
+    use core::slice;
+
+    use rand::{RngCore, SeedableRng};
+    use rand_chacha::ChaCha20Rng;
+    use rust_bitcoin_m31::qm31_equalverify;
+    use stwo_prover::core::{
+        circle::CirclePoint,
+        fields::{
+            m31::{self, M31},
+            qm31::QM31,
+        },
+    };
+
+    use crate::fibonacci::{FibonacciComposition, FibonacciCompositionGadget};
+    use crate::treepp::*;
+
+    #[test]
+    fn test_boundary_constraint_eval_quotient_by_mask() {
+        let log_size = 5;
+        let claim = m31::M31::from_u32_unchecked(443693538);
+
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        let z = CirclePoint {
+            x: QM31::from_m31(
+                M31::reduce(prng.next_u64()),
+                M31::reduce(prng.next_u64()),
+                M31::reduce(prng.next_u64()),
+                M31::reduce(prng.next_u64()),
+            ),
+            y: QM31::from_m31(
+                M31::reduce(prng.next_u64()),
+                M31::reduce(prng.next_u64()),
+                M31::reduce(prng.next_u64()),
+                M31::reduce(prng.next_u64()),
+            ),
+        };
+
+        let fz = QM31::from_m31(
+            M31::reduce(prng.next_u64()),
+            M31::reduce(prng.next_u64()),
+            M31::reduce(prng.next_u64()),
+            M31::reduce(prng.next_u64()),
+        );
+
+        let res = FibonacciComposition::boundary_constraint_eval_quotient_by_mask(
+            log_size,
+            claim,
+            z,
+            slice::from_ref(&fz).try_into().unwrap(),
+        );
+
+        let script = script! {
+            { FibonacciCompositionGadget::boundary_constraint_eval_quotient_by_mask_hint(log_size, claim, z, fz) } //hint
+            { fz }
+            { z.x }
+            { z.y }
+            { FibonacciCompositionGadget::boundary_constraint_eval_quotient_by_mask(log_size,claim) }
+            { res }
+            qm31_equalverify
+            OP_TRUE
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success);
+    }
+}

--- a/src/fibonacci/bitcoin_script.rs
+++ b/src/fibonacci/bitcoin_script.rs
@@ -227,10 +227,12 @@ mod test {
         examples::fibonacci::Fibonacci,
     };
 
-    use crate::fibonacci::{FibonacciComposition, FibonacciCompositionGadget};
     use crate::treepp::*;
+    use crate::{
+        fibonacci::{FibonacciComposition, FibonacciCompositionGadget},
+        tests_utils::report::report_bitcoin_script_size,
+    };
 
-    //TODO: efficiency report
     #[test]
     fn test_eval_composition_polynomial_at_point() {
         let log_size = 5;
@@ -246,6 +248,14 @@ mod test {
         let component_traces = vec![trace];
 
         let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        let composition_polynomial_script =
+            FibonacciCompositionGadget::eval_composition_polynomial_at_point(log_size, claim);
+        report_bitcoin_script_size(
+            "Fibonacci",
+            "eval_composition_polynomial_at_point",
+            composition_polynomial_script.len(),
+        );
 
         for _ in 0..20 {
             let random_coeff = QM31::from_m31(
@@ -295,7 +305,7 @@ mod test {
                 { comp[0][0] }
                 { z.x }
                 { z.y }
-                { FibonacciCompositionGadget::eval_composition_polynomial_at_point(log_size, claim) }
+                { composition_polynomial_script.clone() }
                 { res }
                 qm31_equalverify
                 OP_TRUE
@@ -305,13 +315,20 @@ mod test {
         }
     }
 
-    //TODO: efficiency report
     #[test]
     fn test_boundary_constraint_eval_quotient_by_mask() {
         let log_size = 5;
         let claim = m31::M31::from_u32_unchecked(443693538);
 
         let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        let boundary_constraint_script =
+            FibonacciCompositionGadget::boundary_constraint_eval_quotient_by_mask(log_size, claim);
+        report_bitcoin_script_size(
+            "Fibonacci",
+            "boundary_constraint_eval_quotient_by_mask",
+            boundary_constraint_script.len(),
+        );
 
         for _ in 0..20 {
             let z = CirclePoint {
@@ -348,7 +365,7 @@ mod test {
                 { fz }
                 { z.x }
                 { z.y }
-                { FibonacciCompositionGadget::boundary_constraint_eval_quotient_by_mask(log_size,claim) }
+                { boundary_constraint_script.clone() }
                 { res }
                 qm31_equalverify
                 OP_TRUE
@@ -364,6 +381,14 @@ mod test {
         let log_size = 5;
 
         let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        let step_constraint_script =
+            FibonacciCompositionGadget::step_constraint_eval_quotient_by_mask(log_size);
+        report_bitcoin_script_size(
+            "Fibonacci",
+            "step_constraint_eval_quotient_by_mask",
+            step_constraint_script.len(),
+        );
 
         for _ in 0..20 {
             let z = CirclePoint {
@@ -415,7 +440,7 @@ mod test {
                 { fz }
                 { z.x }
                 { z.y }
-                { FibonacciCompositionGadget::step_constraint_eval_quotient_by_mask(log_size) }
+                { step_constraint_script.clone() }
                 { res }
                 qm31_equalverify
                 OP_TRUE

--- a/src/fibonacci/bitcoin_script.rs
+++ b/src/fibonacci/bitcoin_script.rs
@@ -253,7 +253,11 @@ mod test {
             FibonacciCompositionGadget::eval_composition_polynomial_at_point(log_size, claim);
         report_bitcoin_script_size(
             "Fibonacci",
-            "eval_composition_polynomial_at_point",
+            format!(
+                "eval_composition_polynomial_at_point(log_size={})",
+                log_size
+            )
+            .as_str(),
             composition_polynomial_script.len(),
         );
 
@@ -326,7 +330,11 @@ mod test {
             FibonacciCompositionGadget::boundary_constraint_eval_quotient_by_mask(log_size, claim);
         report_bitcoin_script_size(
             "Fibonacci",
-            "boundary_constraint_eval_quotient_by_mask",
+            format!(
+                "boundary_constraint_eval_quotient_by_mask(log_size={})",
+                log_size
+            )
+            .as_str(),
             boundary_constraint_script.len(),
         );
 
@@ -385,7 +393,11 @@ mod test {
             FibonacciCompositionGadget::step_constraint_eval_quotient_by_mask(log_size);
         report_bitcoin_script_size(
             "Fibonacci",
-            "step_constraint_eval_quotient_by_mask",
+            format!(
+                "step_constraint_eval_quotient_by_mask(log_size={})",
+                log_size
+            )
+            .as_str(),
             step_constraint_script.len(),
         );
 

--- a/src/fibonacci/mod.rs
+++ b/src/fibonacci/mod.rs
@@ -10,13 +10,12 @@ use stwo_prover::core::{
     },
 };
 
-///fibonacci composition polynomial-related methods are private, so we need to copy-paste them from stwo
+///Fibonacci composition polynomial-related methods are PRIVATE, so we need to copy-paste them from stwo!
+/// TODO: solve this problem
 pub struct FibonacciComposition;
 
 impl FibonacciComposition {
-    /// Evaluates the step constraint quotient polynomial on a single point.
-    /// The step constraint is defined as:
-    ///   mask[0]^2 + mask[1]^2 - mask[2]
+    ///step
     fn step_constraint_eval_quotient_by_mask<F: ExtensionOf<BaseField>>(
         log_size: u32,
         point: CirclePoint<F>,
@@ -47,10 +46,6 @@ impl FibonacciComposition {
     ) -> F {
         let constraint_zero_domain = Coset::subgroup(log_size);
         let p = constraint_zero_domain.at(constraint_zero_domain.size() - 1);
-        // On (1,0), we should get 1.
-        // On p, we should get self.claim.
-        // 1 + y * (self.claim - 1) * p.y^-1
-        // TODO(spapini): Cache the constant.
         let linear = F::one() + point.y * (claim - BaseField::one()) * p.y.inverse();
 
         let num = mask[0] - linear;

--- a/src/oods/bitcoin_script.rs
+++ b/src/oods/bitcoin_script.rs
@@ -15,10 +15,10 @@ impl OODSGadget {
     ///
     /// hint:
     ///  w - qm31 hint (5 elements)
-    ///
-    /// input:
     ///  x - (1-t^2)/(1+t^2), where t is extracted from channel (4 elements)
     ///  y - 2t/(1+t^2), where t is extracted from channel (4 elements)
+    ///
+    /// input:
     ///  channel
     ///
     /// output:


### PR DESCRIPTION
Implemented the (Fibonacci) composition polynomial inside the Fibonacci module. It doesn't have all the abstractions as in Stwo because we are not trying to build something general.

Note: Because in Stwo `step_constraint_eval_quotient_by_mask()` and `boundary_constraint_eval_quotient_by_mask()`, are PRIVATE, their code had to be copied to fibonacci/mod.rs in 'FibonacciComposition'.

How should we deal with this?

PS added "itertools" dependency.
