### PR TITLE
Test if link-dead-code improves coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           name: bitcoin-scripts-performance-report
           path: target/bitcoin_scripts_performance_report.csv
       - name: Generate coverage report
-        run: cargo install cargo-tarpaulin && cargo tarpaulin --out Xml
+        run: cargo install cargo-tarpaulin && RUSTFLAGS="-C link-dead-code" cargo tarpaulin --out Xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:


### PR DESCRIPTION
The coverage report seems to miss certain lines. This PR tries to see if this can be lifted by letting the compiler link dead code when checking coverage.