### PR TITLE
Update the cargo-husky hook script with full tests

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,0 +1,9 @@
+set -e
+
+echo '+cargo test -- --nocapture'
+cargo test -- --nocapture
+echo '+cargo clippy --all --all-features --all-targets -- -D warnings'
+cargo clippy --all --all-features --all-targets -- -D warnings
+echo '+cargo +nightly fmt --all -- --check'
+cargo +nightly fmt --all -- --check
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ itertools = "0.12.0"
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = false
-features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy", "run-cargo-fmt"]
+features = ["user-hooks"]
 
 [profile.dev]
 opt-level = 3


### PR DESCRIPTION
The default cargo-husky test doesn't check all the targets in clippy and there could be inconsistency with CI.

This PR modifies the pre-commit hook to follow the CI.