### PR TITLE
Convert the stwo Merkle proofs into deterministic proofs

### DIFF
--- a/src/merkle_tree/mod.rs
+++ b/src/merkle_tree/mod.rs
@@ -1,7 +1,9 @@
-use stwo_prover::core::fields::m31::M31;
+use std::collections::{BTreeSet, HashMap};
+use stwo_prover::core::fields::m31::{BaseField, M31};
 use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hash;
 use stwo_prover::core::vcs::bws_sha256_merkle::BWSSha256MerkleHasher;
 use stwo_prover::core::vcs::ops::MerkleHasher;
+use stwo_prover::core::vcs::prover::MerkleDecommitment;
 
 mod bitcoin_script;
 use crate::treepp::pushable::{Builder, Pushable};
@@ -133,12 +135,121 @@ impl Pushable for &MerkleTreeTwinProof {
     }
 }
 
+impl MerkleTreeTwinProof {
+    /// Convert a stwo Merkle proof into twin proofs for each pairs of queries.
+    pub fn from_stwo_proof(
+        logn: usize,
+        queries_parents: &Vec<usize>,
+        values: &Vec<Vec<BaseField>>,
+        merkle_decommitment: &MerkleDecommitment<BWSSha256MerkleHasher>,
+    ) -> Vec<Self> {
+        // find out all the queried positions and sort them
+        let mut queries = vec![];
+        for &queries_parent in queries_parents.iter() {
+            queries.push(queries_parent << 1);
+            queries.push((queries_parent << 1) + 1);
+        }
+        queries.sort_unstable();
+        queries.dedup();
+
+        // get the number of columns
+        let column_num = values.len();
+
+        // create the new value map
+        let mut queries_values_map = HashMap::new();
+        for (idx, &query) in queries.iter().enumerate() {
+            let mut v = vec![];
+            for i in 0..column_num {
+                v.push(values[i][idx]);
+            }
+            queries_values_map.insert(query, v);
+        }
+
+        // require the column witness to be empty
+        assert!(merkle_decommitment.column_witness.is_empty());
+
+        // turn hash witness into an iterator
+        let mut hash_iterator = merkle_decommitment.hash_witness.iter();
+
+        // create the merkle partial tree
+        let mut layers: Vec<HashMap<usize, BWSSha256Hash>> = vec![];
+
+        // create the leaf layer
+        let mut layer = HashMap::new();
+        for (&query, value) in queries_values_map.iter() {
+            layer.insert(query, BWSSha256MerkleHasher::hash_node(None, value));
+        }
+        layers.push(layer);
+
+        let mut positions = queries_parents.clone();
+        positions.sort_unstable();
+
+        for i in 0..(logn - 1) {
+            let mut layer = HashMap::new();
+            let mut parents = BTreeSet::new();
+
+            for &position in positions.iter() {
+                layer.insert(
+                    position,
+                    BWSSha256MerkleHasher::hash_node(
+                        Some((
+                            layers[i].get(&(position << 1)).unwrap().clone(),
+                            layers[i].get(&((position << 1) + 1)).unwrap().clone(),
+                        )),
+                        &[],
+                    ),
+                );
+
+                if !positions.contains(&(position ^ 1)) && !layer.contains_key(&(position ^ 1)) {
+                    layer.insert(position ^ 1, hash_iterator.next().unwrap().clone());
+                }
+                parents.insert(position >> 1);
+            }
+
+            layers.push(layer);
+            positions = parents.iter().copied().collect::<Vec<usize>>();
+        }
+
+        assert_eq!(hash_iterator.next(), None);
+
+        let mut res = vec![];
+        for &queries_parent in queries_parents.iter() {
+            let mut siblings = vec![];
+
+            let mut cur = queries_parent;
+            for i in 1..logn {
+                siblings.push(layers[i].get(&(cur ^ 1)).unwrap().clone());
+                cur >>= 1;
+            }
+
+            res.push(Self {
+                left: queries_values_map
+                    .get(&(queries_parent << 1))
+                    .unwrap()
+                    .clone(),
+                right: queries_values_map
+                    .get(&((queries_parent << 1) + 1))
+                    .unwrap()
+                    .clone(),
+                siblings: siblings,
+            });
+        }
+        res
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use crate::merkle_tree::MerkleTree;
+    use crate::merkle_tree::{MerkleTree, MerkleTreeTwinProof};
     use crate::utils::get_rand_qm31;
-    use rand::{Rng, SeedableRng};
+    use itertools::Itertools;
+    use rand::{Rng, RngCore, SeedableRng};
     use rand_chacha::ChaCha20Rng;
+    use std::collections::BTreeMap;
+    use stwo_prover::core::backend::CpuBackend;
+    use stwo_prover::core::fields::m31::BaseField;
+    use stwo_prover::core::vcs::bws_sha256_merkle::BWSSha256MerkleHasher;
+    use stwo_prover::core::vcs::prover::MerkleProver;
 
     #[test]
     fn test_merkle_tree() {
@@ -165,6 +276,57 @@ mod test {
                 &proof,
                 query
             ));
+        }
+    }
+
+    #[test]
+    fn test_from_stwo_proof() {
+        const LOG_SIZE: usize = 12;
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        for _ in 0..10 {
+            let mut polynomials = vec![];
+            for _ in 0..4 {
+                let mut polynomial = vec![];
+                for _ in 0..(1 << LOG_SIZE) {
+                    polynomial.push(BaseField::reduce(prng.next_u64()));
+                }
+                polynomials.push(polynomial);
+            }
+
+            let polynomials_ref = polynomials.iter().collect::<Vec<&Vec<BaseField>>>();
+
+            let prover =
+                MerkleProver::<CpuBackend, BWSSha256MerkleHasher>::commit(polynomials_ref.clone());
+
+            let queries = (0..20)
+                .map(|_| prng.gen::<usize>() % (1 << LOG_SIZE))
+                .map(|x| x >> 1)
+                .collect::<Vec<usize>>();
+
+            let (values, decommitment) = prover.decommit(
+                BTreeMap::from([(
+                    LOG_SIZE as u32,
+                    queries
+                        .iter()
+                        .sorted()
+                        .dedup()
+                        .flat_map(|&x| [x << 1, (x << 1) + 1])
+                        .collect::<Vec<usize>>(),
+                )]),
+                polynomials_ref,
+            );
+
+            let proofs =
+                MerkleTreeTwinProof::from_stwo_proof(LOG_SIZE, &queries, &values, &decommitment);
+            for (&query, proof) in queries.iter().zip(proofs.iter()) {
+                assert!(MerkleTree::verify_twin(
+                    &prover.root(),
+                    LOG_SIZE,
+                    proof,
+                    query << 1
+                ));
+            }
         }
     }
 }

--- a/src/merkle_tree/mod.rs
+++ b/src/merkle_tree/mod.rs
@@ -184,6 +184,7 @@ impl MerkleTreeTwinProof {
         let mut positions = queries_parents.to_vec();
         positions.sort_unstable();
 
+        // create the intermediate layers
         for i in 0..(logn - 1) {
             let mut layer = HashMap::new();
             let mut parents = BTreeSet::new();
@@ -212,6 +213,7 @@ impl MerkleTreeTwinProof {
 
         assert_eq!(hash_iterator.next(), None);
 
+        // cheery-pick the Merkle tree paths to construct the deterministic proofs
         let mut res = vec![];
         for &queries_parent in queries_parents.iter() {
             let mut siblings = vec![];


### PR DESCRIPTION
Stwo has a mechanism to store Merkle proofs in a very succinct format by avoiding redundancy. However, it is difficult to handle in the Bitcoin script. 

Previously, in #53, we have a new implementation of Merkle trees and proofs that have deterministic structures. This PR converts the Merkle proofs that appear in the stwo original proof into these deterministic proofs.