### PR TITLE
Add a profiler implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ opt-level = 3
 
 [profile.release]
 lto = true
+
+[features]
+profiler = ["bitcoin-scriptexec/profiler"]

--- a/src/channel/bitcoin_script.rs
+++ b/src/channel/bitcoin_script.rs
@@ -1,5 +1,5 @@
 use crate::treepp::*;
-use crate::utils::{hash_qm31_gadget, trim_m31_gadget};
+use crate::utils::{hash, hash_qm31_gadget, trim_m31_gadget};
 use crate::OP_HINT;
 use rust_bitcoin_m31::MOD;
 
@@ -17,7 +17,7 @@ impl Sha256ChannelGadget {
     /// - new channel digest
     pub fn mix_digest() -> Script {
         script! {
-            OP_CAT OP_SHA256
+            OP_CAT hash
         }
     }
 
@@ -33,7 +33,7 @@ impl Sha256ChannelGadget {
         script! {
             OP_TOALTSTACK
             hash_qm31_gadget
-            OP_FROMALTSTACK OP_CAT OP_SHA256
+            OP_FROMALTSTACK OP_CAT hash
         }
     }
 
@@ -69,8 +69,8 @@ impl Sha256ChannelGadget {
     /// - qm31
     pub fn draw_felt_with_hint() -> Script {
         script! {
-            OP_DUP OP_SHA256 OP_SWAP
-            OP_PUSHBYTES_1 OP_PUSHBYTES_0 OP_CAT OP_SHA256
+            OP_DUP hash OP_SWAP
+            OP_PUSHBYTES_1 OP_PUSHBYTES_0 OP_CAT hash
             { Self::unpack_multi_m31(4) }
         }
     }
@@ -82,8 +82,8 @@ impl Sha256ChannelGadget {
     ///    all the numbers (m)
     pub fn draw_numbers_with_hint(m: usize, logn: usize) -> Script {
         script! {
-            OP_DUP OP_SHA256 OP_SWAP
-            OP_PUSHBYTES_1 OP_PUSHBYTES_0 OP_CAT OP_SHA256
+            OP_DUP hash OP_SWAP
+            OP_PUSHBYTES_1 OP_PUSHBYTES_0 OP_CAT hash
             { Self::unpack_multi_m31(m) }
             for i in 0..m {
                 { i } OP_ROLL { trim_m31_gadget(logn) }
@@ -169,7 +169,7 @@ mod test {
     use crate::channel::{generate_hints, ChannelWithHint, Sha256Channel, Sha256ChannelGadget};
     use crate::tests_utils::report::report_bitcoin_script_size;
     use crate::treepp::*;
-    use crate::utils::{get_rand_qm31, hash_qm31, hash_qm31_gadget};
+    use crate::utils::{get_rand_qm31, hash, hash_qm31, hash_qm31_gadget};
     use bitcoin_script::script;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
@@ -283,8 +283,8 @@ mod test {
             let script = script! {
                 { hint }
                 { a }
-                OP_DUP OP_SHA256 OP_SWAP
-                OP_PUSHBYTES_1 OP_PUSHBYTES_0 OP_CAT OP_SHA256
+                OP_DUP hash OP_SWAP
+                OP_PUSHBYTES_1 OP_PUSHBYTES_0 OP_CAT hash
                 { Sha256ChannelGadget::unpack_multi_m31(8) }
                 for i in 0..8 {
                     { b[i] }

--- a/src/fibonacci/bitcoin_script/fold.rs
+++ b/src/fibonacci/bitcoin_script/fold.rs
@@ -3,9 +3,10 @@ use crate::fri::FFTGadget;
 use crate::merkle_tree::MerkleTreePathGadget;
 use crate::treepp::*;
 use crate::utils::{
-    dup_m31_vec_gadget, hash_m31_vec_gadget, limb_to_be_bits_toaltstack,
+    dup_m31_vec_gadget, hash, hash_m31_vec_gadget, limb_to_be_bits_toaltstack,
     m31_vec_from_bottom_gadget, qm31_reverse,
 };
+use bitcoin_scriptexec::{profiler_end, profiler_start};
 use rust_bitcoin_m31::{
     qm31_add, qm31_copy, qm31_equalverify, qm31_mul, qm31_over, qm31_rot, qm31_swap,
 };
@@ -108,7 +109,7 @@ impl FibonacciPerQueryFoldGadget {
                 qm31_reverse qm31_swap
                 // hash the left and keep the hash in the altstack
                 { hash_m31_vec_gadget(4) }
-                OP_SHA256
+                hash
                 OP_TOALTSTACK
 
                 // right
@@ -118,14 +119,16 @@ impl FibonacciPerQueryFoldGadget {
                 qm31_reverse qm31_swap
                 // hash the right
                 { hash_m31_vec_gadget(4) }
-                OP_SHA256
+                hash
 
                 // put the left hash out and merge into the parent hash
                 OP_FROMALTSTACK
                 OP_SWAP
-                OP_CAT OP_SHA256
+                OP_CAT hash
 
+                { profiler_start("merkle tree verification for folding") }
                 { MerkleTreePathGadget::verify((FIB_LOG_SIZE + LOG_BLOWUP_FACTOR - 1) as usize - j) }
+                { profiler_end("merkle tree verification for folding") }
 
                 qm31_rot
 
@@ -136,6 +139,7 @@ impl FibonacciPerQueryFoldGadget {
 
                 qm31_equalverify
 
+                { profiler_start("fft and multiply by alpha in folding") }
                 8 OP_ROLL
                 { FFTGadget::ibutterfly() }
 
@@ -145,6 +149,7 @@ impl FibonacciPerQueryFoldGadget {
                 }
 
                 qm31_mul qm31_add
+                { profiler_end("fft and multiply by alpha in folding") }
             }
 
             // pull the last layer

--- a/src/fibonacci/bitcoin_script/mod.rs
+++ b/src/fibonacci/bitcoin_script/mod.rs
@@ -134,5 +134,7 @@ mod test {
             convert_to_witness(witness).unwrap(),
         );
         assert!(exec_result.success);
+        #[cfg(feature = "profiler")]
+        exec_result.profiler.print_stats();
     }
 }

--- a/src/fibonacci/split/mod.rs
+++ b/src/fibonacci/split/mod.rs
@@ -8,7 +8,7 @@ use crate::fibonacci::prepare::PrepareHints;
 use crate::fibonacci::quotients::PerQueryQuotientHint;
 use crate::fibonacci::FIB_LOG_SIZE;
 use crate::treepp::*;
-use crate::utils::clean_stack;
+use crate::utils::{clean_stack, hash};
 use crate::OP_HINT;
 use bitcoin_scriptexec::utils::scriptint_vec;
 use covenants_gadgets::utils::stack_hash::StackHash;
@@ -322,7 +322,7 @@ impl CovenantProgram for FibonacciSplitProgram {
 
                 OP_2DUP
                 OP_CAT
-                OP_SHA256
+                hash
                 OP_FROMALTSTACK OP_EQUALVERIFY
             }
         }

--- a/src/merkle_tree/bitcoin_script.rs
+++ b/src/merkle_tree/bitcoin_script.rs
@@ -1,6 +1,7 @@
 use crate::treepp::*;
 use crate::utils::{
-    dup_m31_vec_gadget, hash_m31_vec_gadget, limb_to_be_bits_toaltstack, m31_vec_from_bottom_gadget,
+    dup_m31_vec_gadget, hash, hash_m31_vec_gadget, limb_to_be_bits_toaltstack,
+    m31_vec_from_bottom_gadget,
 };
 use crate::OP_HINT;
 
@@ -18,7 +19,7 @@ impl MerkleTreeTwinGadget {
 
             // hash the left and keep the hash in the altstack
             { hash_m31_vec_gadget(len) }
-            OP_SHA256
+            hash
             OP_TOALTSTACK
 
             // right
@@ -29,11 +30,11 @@ impl MerkleTreeTwinGadget {
 
             // hash the right
             { hash_m31_vec_gadget(len) }
-            OP_SHA256
+            hash
 
             // put the left hash out and merge into the parent hash
             OP_FROMALTSTACK
-            OP_SWAP OP_CAT OP_SHA256
+            OP_SWAP OP_CAT hash
 
             { MerkleTreePathGadget::verify(logn - 1) }
         }
@@ -86,7 +87,7 @@ impl MerkleTreePathGadget {
             for _ in 0..path_len {
                 OP_HINT
                 OP_FROMALTSTACK OP_IF OP_SWAP OP_ENDIF
-                OP_CAT OP_SHA256
+                OP_CAT hash
             }
 
             OP_FROMALTSTACK

--- a/src/pow/bitcoin_script.rs
+++ b/src/pow/bitcoin_script.rs
@@ -1,5 +1,6 @@
 use crate::channel::Sha256ChannelGadget;
 use crate::treepp::*;
+use crate::utils::hash;
 use crate::OP_HINT;
 
 /// Gadget for verifying PoW.
@@ -38,7 +39,7 @@ impl PowGadget {
 
             // compute sha256(channel||nonce)
             OP_2DUP
-            OP_CAT OP_SHA256
+            OP_CAT hash
 
             // stack: channel, nonce, sha256(channel||nonce)
 

--- a/src/precomputed_merkle_tree/bitcoin_script.rs
+++ b/src/precomputed_merkle_tree/bitcoin_script.rs
@@ -1,5 +1,5 @@
 use crate::treepp::*;
-use crate::utils::limb_to_le_bits;
+use crate::utils::{hash, limb_to_le_bits};
 use crate::OP_HINT;
 
 /// Gadget for verifying a Merkle tree path in a precomputed data tree.
@@ -35,7 +35,7 @@ impl PrecomputedMerkleTreeGadget {
             OP_DUP OP_TOALTSTACK
 
             // compute the current element's hash
-            OP_SHA256 OP_CAT OP_SHA256 OP_CAT OP_SHA256
+            hash OP_CAT hash OP_CAT hash
 
             // stack: root_hash, <bits>, leaf-hash
             // altstack: leaf
@@ -61,7 +61,7 @@ impl PrecomputedMerkleTreeGadget {
                 OP_IF OP_SWAP OP_ROT OP_ENDIF
 
                 OP_CAT OP_CAT
-                OP_SHA256
+                hash
             }
 
             // pull the sibling
@@ -74,7 +74,7 @@ impl PrecomputedMerkleTreeGadget {
             // check if we need to swap, and swap if needed
             OP_IF OP_SWAP OP_ENDIF
             OP_CAT
-            OP_SHA256
+            hash
 
             { root.to_vec() }
             OP_EQUALVERIFY

--- a/src/utils/bitcoin_script.rs
+++ b/src/utils/bitcoin_script.rs
@@ -1,7 +1,15 @@
 use crate::treepp::*;
 use crate::OP_HINT;
+use bitcoin_scriptexec::{profiler_end, profiler_start};
 use sha2::{Digest, Sha256};
 use std::cmp::min;
+
+/// Call the selected hash function.
+pub fn hash() -> Script {
+    script! {
+        { profiler_start("op_sha256") } OP_SHA256 { profiler_end("op_sha256") }
+    }
+}
 
 /// Gadget for trimming away a m31 element to keep only logn bits.
 pub fn trim_m31_gadget(logn: usize) -> Script {
@@ -62,9 +70,9 @@ pub fn hash_m31_vec_gadget(len: usize) -> Script {
         }
     } else {
         script! {
-            OP_SHA256
+            hash
             for _ in 1..len {
-                OP_CAT OP_SHA256
+                OP_CAT hash
             }
         }
     }


### PR DESCRIPTION
This PR adds a profiler support. Now, if the code is run with the "profiler" features, the test_verifier would print out some information about the weight units contributed by different places. 

If the profiler feature is not turned off, it would not have any side effect. By default, it is off.