### PR TITLE
Improve Merkle Tree and Fibonacci scripts

### DIFF
--- a/src/fibonacci/bitcoin_script/fold.rs
+++ b/src/fibonacci/bitcoin_script/fold.rs
@@ -3,8 +3,8 @@ use crate::fri::FFTGadget;
 use crate::merkle_tree::MerkleTreePathGadget;
 use crate::treepp::*;
 use crate::utils::{
-    dup_m31_vec_gadget, hash, hash_m31_vec_gadget, limb_to_be_bits, m31_vec_from_bottom_gadget,
-    qm31_reverse,
+    dup_m31_vec_gadget, hash, hash_m31_vec_gadget, limb_to_be_bits_toaltstack_except_lowest_1bit,
+    limb_to_be_bits_toaltstack_except_lowest_2bits, m31_vec_from_bottom_gadget, qm31_reverse,
 };
 use bitcoin_scriptexec::{profiler_end, profiler_start};
 use rust_bitcoin_m31::{
@@ -38,8 +38,7 @@ impl FibonacciPerQueryFoldGadget {
 
             // pull the query
             { 4 + 4 + 15 + 24 + 4 + 12 + 16 + 12 + 8 + 24 + (2 + 8) * N_QUERIES + N_QUERIES - query_idx - 1 } OP_PICK
-            { limb_to_be_bits(FIB_LOG_SIZE + LOG_BLOWUP_FACTOR + 1) }
-            OP_TOALTSTACK OP_DROP
+            { limb_to_be_bits_toaltstack_except_lowest_1bit(FIB_LOG_SIZE + LOG_BLOWUP_FACTOR + 1) }
 
             // pull y inverse (last twiddle factor)
             8 OP_ROLL
@@ -95,9 +94,7 @@ impl FibonacciPerQueryFoldGadget {
 
                 // push the root hash to the altstack, first
                 OP_SWAP OP_TOALTSTACK
-                { limb_to_be_bits(FIB_LOG_SIZE + LOG_BLOWUP_FACTOR + 1) }
-                OP_DROP
-                OP_DROP
+                { limb_to_be_bits_toaltstack_except_lowest_2bits(FIB_LOG_SIZE + LOG_BLOWUP_FACTOR + 1) }
                 for _ in 0..j {
                     OP_FROMALTSTACK OP_DROP
                 }

--- a/src/fibonacci/bitcoin_script/fold.rs
+++ b/src/fibonacci/bitcoin_script/fold.rs
@@ -3,8 +3,8 @@ use crate::fri::FFTGadget;
 use crate::merkle_tree::MerkleTreePathGadget;
 use crate::treepp::*;
 use crate::utils::{
-    dup_m31_vec_gadget, hash_m31_vec_gadget, limb_to_be_bits_toaltstack,
-    m31_vec_from_bottom_gadget, qm31_reverse,
+    dup_m31_vec_gadget, hash_m31_vec_gadget, limb_to_be_bits, m31_vec_from_bottom_gadget,
+    qm31_reverse,
 };
 use rust_bitcoin_m31::{
     qm31_add, qm31_copy, qm31_equalverify, qm31_mul, qm31_over, qm31_rot, qm31_swap,
@@ -37,8 +37,8 @@ impl FibonacciPerQueryFoldGadget {
 
             // pull the query
             { 4 + 4 + 15 + 24 + 4 + 12 + 16 + 12 + 8 + 24 + (2 + 8) * N_QUERIES + N_QUERIES - query_idx - 1 } OP_PICK
-            { limb_to_be_bits_toaltstack(FIB_LOG_SIZE + LOG_BLOWUP_FACTOR + 1) }
-            OP_FROMALTSTACK OP_DROP
+            { limb_to_be_bits(FIB_LOG_SIZE + LOG_BLOWUP_FACTOR + 1) }
+            OP_TOALTSTACK OP_DROP
 
             // pull y inverse (last twiddle factor)
             8 OP_ROLL
@@ -94,9 +94,9 @@ impl FibonacciPerQueryFoldGadget {
 
                 // push the root hash to the altstack, first
                 OP_SWAP OP_TOALTSTACK
-                { limb_to_be_bits_toaltstack(FIB_LOG_SIZE + LOG_BLOWUP_FACTOR + 1) }
-                OP_FROMALTSTACK OP_DROP
-                OP_FROMALTSTACK OP_DROP
+                { limb_to_be_bits(FIB_LOG_SIZE + LOG_BLOWUP_FACTOR + 1) }
+                OP_DROP
+                OP_DROP
                 for _ in 0..j {
                     OP_FROMALTSTACK OP_DROP
                 }

--- a/src/merkle_tree/bitcoin_script.rs
+++ b/src/merkle_tree/bitcoin_script.rs
@@ -1,6 +1,6 @@
 use crate::treepp::*;
 use crate::utils::{
-    dup_m31_vec_gadget, hash_m31_vec_gadget, limb_to_be_bits_toaltstack, m31_vec_from_bottom_gadget,
+    dup_m31_vec_gadget, hash_m31_vec_gadget, limb_to_be_bits, m31_vec_from_bottom_gadget,
 };
 use crate::OP_HINT;
 
@@ -55,8 +55,8 @@ impl MerkleTreeTwinGadget {
         script! {
             // push the root hash to the altstack, first
             OP_SWAP OP_TOALTSTACK
-            { limb_to_be_bits_toaltstack(logn as u32) }
-            OP_FROMALTSTACK OP_DROP // drop the lowest bit
+            { limb_to_be_bits(logn as u32) }
+            OP_TOALTSTACK OP_DROP // drop the lowest bit
             { Self::query_and_verify_internal(len, logn) }
         }
     }

--- a/src/merkle_tree/bitcoin_script.rs
+++ b/src/merkle_tree/bitcoin_script.rs
@@ -1,6 +1,7 @@
 use crate::treepp::*;
 use crate::utils::{
-    dup_m31_vec_gadget, hash, hash_m31_vec_gadget, limb_to_be_bits, m31_vec_from_bottom_gadget,
+    dup_m31_vec_gadget, hash, hash_m31_vec_gadget, limb_to_be_bits_toaltstack_except_lowest_1bit,
+    m31_vec_from_bottom_gadget,
 };
 use crate::OP_HINT;
 
@@ -55,8 +56,7 @@ impl MerkleTreeTwinGadget {
         script! {
             // push the root hash to the altstack, first
             OP_SWAP OP_TOALTSTACK
-            { limb_to_be_bits(logn as u32) }
-            OP_TOALTSTACK OP_DROP // drop the lowest bit
+            { limb_to_be_bits_toaltstack_except_lowest_1bit(logn as u32) }
             { Self::query_and_verify_internal(len, logn) }
         }
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -74,16 +74,12 @@ pub fn limb_to_le_bits(num_bits: u32) -> Script {
     limb_to_le_bits_common(num_bits)
 }
 
-/// Convert a limb to big-endian bits but store them in the altstack for now
+/// Convert a limb to big-endian bits
 /// Adapted from https://github.com/BitVM/BitVM/blob/main/src/bigint/bits.rs
 /// due to inability to reconcile the dependency issues between BitVM and stwo.
-pub fn limb_to_be_bits_toaltstack(num_bits: u32) -> Script {
+pub fn limb_to_be_bits(num_bits: u32) -> Script {
     assert!(num_bits >= 2);
-    script! {
-        { limb_to_be_bits_common(num_bits) }
-        OP_TOALTSTACK
-        OP_TOALTSTACK
-    }
+    limb_to_be_bits_common(num_bits)
 }
 
 /// Compute all the twiddle factors.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,5 @@
 mod bitcoin_script;
 
-use crate::treepp::*;
 pub use bitcoin_script::*;
 use rand::RngCore;
 use sha2::{Digest, Sha256};
@@ -64,22 +63,6 @@ pub fn hash_qm31(v: &QM31) -> [u8; 32] {
 /// Trim a m31 element to have only logn bits.
 pub fn trim_m31(v: u32, logn: usize) -> u32 {
     v & ((1 << logn) - 1)
-}
-
-/// Convert a limb to low-endian bits
-/// Adapted from https://github.com/BitVM/BitVM/blob/main/src/bigint/bits.rs
-/// due to inability to reconcile the dependency issues between BitVM and stwo.
-pub fn limb_to_le_bits(num_bits: u32) -> Script {
-    assert!(num_bits >= 2);
-    limb_to_le_bits_common(num_bits)
-}
-
-/// Convert a limb to big-endian bits
-/// Adapted from https://github.com/BitVM/BitVM/blob/main/src/bigint/bits.rs
-/// due to inability to reconcile the dependency issues between BitVM and stwo.
-pub fn limb_to_be_bits(num_bits: u32) -> Script {
-    assert!(num_bits >= 2);
-    limb_to_be_bits_common(num_bits)
 }
 
 /// Compute all the twiddle factors.


### PR DESCRIPTION
Improves the size of the `Fibonacci` and `Merkle Tree` scripts by removing the redundant opcode sequence of `OP_TOALTSTACK OP_FROMALTSTACK`.
- Every `MerkleTree` verification is reduced by 2 bytes
- The Fibonacci verifier is reduced by 208 bytes (3,082,058 => 3,081,850)