### PR TITLE
Syntax changes consistent with the latest stwo

### DIFF
--- a/src/bin/demo.rs
+++ b/src/bin/demo.rs
@@ -19,7 +19,6 @@ use stwo_prover::core::channel::{BWSSha256Channel, Channel};
 use stwo_prover::core::fields::m31::{BaseField, M31};
 use stwo_prover::core::fields::IntoSlice;
 use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hasher;
-use stwo_prover::core::vcs::hasher::Hasher;
 use stwo_prover::examples::fibonacci::Fibonacci;
 use stwo_prover::trace_generation::commit_and_prove;
 

--- a/src/fibonacci/bitcoin_script/mod.rs
+++ b/src/fibonacci/bitcoin_script/mod.rs
@@ -84,7 +84,6 @@ mod test {
     use stwo_prover::core::fields::m31::{BaseField, M31};
     use stwo_prover::core::fields::IntoSlice;
     use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hasher;
-    use stwo_prover::core::vcs::hasher::Hasher;
     use stwo_prover::examples::fibonacci::Fibonacci;
     use stwo_prover::trace_generation::{commit_and_prove, commit_and_verify};
 

--- a/src/fibonacci/fiat_shamir.rs
+++ b/src/fibonacci/fiat_shamir.rs
@@ -25,6 +25,7 @@ use stwo_prover::core::prover::{
 };
 use stwo_prover::core::queries::{Queries, SparseSubCircleDomain};
 use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hash;
+use stwo_prover::core::vcs::bws_sha256_merkle::BWSSha256MerkleHasher;
 use stwo_prover::core::{ColumnVec, InteractionElements, LookupValues};
 use stwo_prover::examples::fibonacci::air::FibonacciAir;
 
@@ -162,12 +163,13 @@ pub struct FiatShamirOutput {
 
 /// Generate Fiat Shamir hints along with fri inputs
 pub fn compute_fiat_shamir_hints(
-    proof: StarkProof,
+    proof: StarkProof<BWSSha256MerkleHasher>,
     channel: &mut BWSSha256Channel,
     air: &FibonacciAir,
 ) -> Result<(FiatShamirOutput, FiatShamirHints), VerificationError> {
     // Read trace commitment.
-    let mut commitment_scheme = CommitmentSchemeVerifier::new();
+    let mut commitment_scheme: CommitmentSchemeVerifier<BWSSha256MerkleHasher> =
+        CommitmentSchemeVerifier::new();
 
     // TODO(spapini): Retrieve column_log_sizes from AirTraceVerifier, and remove the dependency on
     // Air.

--- a/src/fibonacci/mod.rs
+++ b/src/fibonacci/mod.rs
@@ -27,6 +27,7 @@ use stwo_prover::core::circle::CirclePoint;
 use stwo_prover::core::fields::qm31::SecureField;
 use stwo_prover::core::pcs::TreeVec;
 use stwo_prover::core::prover::{InvalidOodsSampleStructure, StarkProof, VerificationError};
+use stwo_prover::core::vcs::bws_sha256_merkle::BWSSha256MerkleHasher;
 use stwo_prover::core::ColumnVec;
 use stwo_prover::examples::fibonacci::air::FibonacciAir;
 
@@ -64,7 +65,7 @@ impl Pushable for VerifierHints {
 
 /// A verifier program that generates hints.
 pub fn verify_with_hints(
-    proof: StarkProof,
+    proof: StarkProof<BWSSha256MerkleHasher>,
     air: &FibonacciAir,
     channel: &mut BWSSha256Channel,
 ) -> Result<VerifierHints, VerificationError> {
@@ -132,8 +133,9 @@ mod test {
     use stwo_prover::core::channel::{BWSSha256Channel, Channel};
     use stwo_prover::core::fields::m31::{BaseField, M31};
     use stwo_prover::core::fields::IntoSlice;
+    use stwo_prover::core::prover::StarkProof;
     use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hasher;
-    use stwo_prover::core::vcs::hasher::Hasher;
+    use stwo_prover::core::vcs::bws_sha256_merkle::BWSSha256MerkleHasher;
     use stwo_prover::examples::fibonacci::Fibonacci;
     use stwo_prover::trace_generation::{commit_and_prove, commit_and_verify};
 
@@ -148,7 +150,8 @@ mod test {
                 .air
                 .component
                 .claim])));
-        let proof = commit_and_prove(&fib.air, channel, vec![trace]).unwrap();
+        let proof: StarkProof<BWSSha256MerkleHasher> =
+            commit_and_prove(&fib.air, channel, vec![trace]).unwrap();
 
         let channel =
             &mut BWSSha256Channel::new(BWSSha256Hasher::hash(BaseField::into_slice(&[fib

--- a/src/fibonacci/prepare.rs
+++ b/src/fibonacci/prepare.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use itertools::Itertools;
 use std::iter::zip;
+use stwo_prover::core::vcs::bws_sha256_merkle::BWSSha256MerkleHasher;
 use stwo_prover::core::{
     backend::cpu::quotients::{batch_random_coeffs, denominator_inverses},
     constraints::complex_conjugate_line_coeffs_normalized,
@@ -52,7 +53,7 @@ pub struct PrepareOutput {
 /// prepare output for quotients and verifier hints
 pub fn compute_prepare_hints(
     fs_output: &FiatShamirOutput,
-    proof: &StarkProof,
+    proof: &StarkProof<BWSSha256MerkleHasher>,
 ) -> Result<(PrepareOutput, PrepareHints), VerificationError> {
     let column_size: Vec<u32> = fs_output
         .commitment_scheme_column_log_sizes

--- a/src/fibonacci/split/mod.rs
+++ b/src/fibonacci/split/mod.rs
@@ -22,7 +22,7 @@ use stwo_prover::core::fields::{
     IntoSlice,
 };
 use stwo_prover::core::prover::N_QUERIES;
-use stwo_prover::core::vcs::{bws_sha256_hash::BWSSha256Hasher, hasher::Hasher};
+use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hasher;
 
 /// The state of the Fibonacci split program.
 #[derive(Clone, Debug)]
@@ -438,7 +438,6 @@ mod test {
     use stwo_prover::core::fields::m31::{BaseField, M31};
     use stwo_prover::core::fields::IntoSlice;
     use stwo_prover::core::vcs::bws_sha256_hash::BWSSha256Hasher;
-    use stwo_prover::core::vcs::hasher::Hasher;
     use stwo_prover::examples::fibonacci::Fibonacci;
     use stwo_prover::trace_generation::commit_and_prove;
 


### PR DESCRIPTION
Since the stwo fork has been updated to match the latest stwo, there are some syntax changes that this repo needs to inherit.