### PR TITLE
hardcode the tarpulin version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           name: bitcoin-scripts-performance-report
           path: target/bitcoin_scripts_performance_report.csv
       - name: Generate coverage report
-        run: cargo install cargo-tarpaulin && cargo tarpaulin --engine llvm --out Xml
+        run: cargo install cargo-tarpaulin --version v0.31.2 && cargo tarpaulin --engine llvm --out Xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           name: bitcoin-scripts-performance-report
           path: target/bitcoin_scripts_performance_report.csv
       - name: Generate coverage report
-        run: cargo install cargo-tarpaulin --version v0.31.2 && cargo tarpaulin --engine llvm --out Xml
+        run: cargo install cargo-tarpaulin --version 0.31.2 && cargo tarpaulin --engine llvm --out Xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         with:


### PR DESCRIPTION
v0.31.3 seems to require Rust >= 1.78.0. Before stwo bumps up the dependency on Rust nightly toolchain, we would not be able to work with Tarpulin v0.31.3.